### PR TITLE
Architecture paragraph was removed

### DIFF
--- a/source/guides/command-line/applications.md
+++ b/source/guides/command-line/applications.md
@@ -12,23 +12,6 @@ We can generate a new project via `hanami new`, followed by the name that we wan
 % hanami new bookshelf
 ```
 
-### Architecture
-
-The default architecture for a newly generated project is _Container_.
-
-We can use the `--architecture` argument (aliased as `--arch`) to specify a different architecture.
-
-It supports:
-
-  * `container` (default)
-  * `app`
-
-The following command will generate an `admin` project that uses the _Application_ architecture.
-
-```shell
-% hanami new admin --arch=app
-```
-
 ### Database
 
 The default database engine is SQLite.


### PR DESCRIPTION
Architecture flag is not supported and Hanami supports only container architecture.